### PR TITLE
Return ownerHasChanged as a result of a mission

### DIFF
--- a/entities/mission.go
+++ b/entities/mission.go
@@ -139,7 +139,7 @@ func calculateTravelTime(source, target *vec2d.Vector, speed int64) time.Duratio
 // If that's true we simply increment the ship count on that planet. If not we do the
 // math and decrease the count ship on the attacked planet. We should check if the attacker
 // should own that planet, which comes with all the changing colors and owner stuff.
-func (m *Mission) EndAttackMission(target *Planet) (excessShips int32) {
+func (m *Mission) EndAttackMission(target *Planet) (excessShips int32, ownerHasChanged bool) {
 	if target.Owner == m.Player {
 		m.Target.Owner = target.Owner
 		m.Type = "Supply"
@@ -155,6 +155,7 @@ func (m *Mission) EndAttackMission(target *Planet) (excessShips int32) {
 				target.SetShipCount(m.ShipCount - target.ShipCount)
 				target.Owner = m.Player
 				target.Color = m.Color
+				ownerHasChanged = true
 			}
 		}
 	}
@@ -164,24 +165,24 @@ func (m *Mission) EndAttackMission(target *Planet) (excessShips int32) {
 // End Supply Mission: We simply increase the ship count and we're done :P
 // If however the owner of the target planet has changed we change the mission type
 // to attack.
-func (m *Mission) EndSupplyMission(target *Planet) int32 {
+func (m *Mission) EndSupplyMission(target *Planet) (int32, bool) {
 	if target.Owner != m.Target.Owner {
 		m.Type = "Attack"
 		return m.EndAttackMission(target)
 	}
 
 	target.SetShipCount(target.ShipCount + m.ShipCount)
-	return 0
+	return 0, false
 }
 
 // End Spy Mission: Create a spy report for that planet and find a way to notify the logged in
 // instances of the user who sent this mission.
-func (m *Mission) EndSpyMission(target *Planet) int32 {
+func (m *Mission) EndSpyMission(target *Planet) (int32, bool) {
 	if target.Owner == m.Player {
 		m.Target.Owner = target.Owner
 		return m.EndSupplyMission(target)
 	}
 	CreateSpyReport(target, m)
 	m.ShipCount -= 1
-	return 0
+	return 0, false
 }

--- a/entities/mission_test.go
+++ b/entities/mission_test.go
@@ -57,9 +57,17 @@ func TestMissionMarshalling(t *testing.T) {
 }
 
 func TestEndAttackMission(t *testing.T) {
-	var excessShips int32
+	var (
+		excessShips     int32
+		ownerHasChanged bool
+	)
 
-	excessShips = secondMission.EndAttackMission(&endPlanet)
+	excessShips, ownerHasChanged = secondMission.EndAttackMission(&endPlanet)
+
+	if ownerHasChanged {
+		t.Error("Owner has changed after a mission weaker than his planet")
+	}
+
 	if endPlanet.GetShipCount() != 12 {
 		t.Error("End Planet ship count was expected  to be 12 but it is:", endPlanet.GetShipCount())
 	}
@@ -69,7 +77,12 @@ func TestEndAttackMission(t *testing.T) {
 	}
 
 	mission.ShipCount = 15
-	excessShips = mission.EndAttackMission(&endPlanet)
+	excessShips, ownerHasChanged = mission.EndAttackMission(&endPlanet)
+
+	if !ownerHasChanged {
+		t.Error("Owner did not change after attack with a stronger mission")
+	}
+
 	if endPlanet.GetShipCount() != 3 {
 		t.Error("End Planet ship count was expected  to be 3 but it is:", endPlanet.GetShipCount())
 	}
@@ -84,12 +97,21 @@ func TestEndAttackMission(t *testing.T) {
 }
 
 func TestEndAttackMissionDenyTakeover(t *testing.T) {
-	var excessShips int32
+	var (
+		excessShips     int32
+		ownerHasChanged bool
+	)
+
 	endPlanet := new(Planet)
 	*endPlanet = Planet{"", Color{0.59215686, 0.59215686, 0.59215686}, vec2d.New(2, 2), true, 6, 3, timeStamp, 2, 0, "chochko"}
 
 	mission.ShipCount = 5
-	excessShips = mission.EndAttackMission(endPlanet)
+	excessShips, ownerHasChanged = mission.EndAttackMission(endPlanet)
+
+	if ownerHasChanged {
+		t.Error("Owner has changed after a mission weaker than his planet")
+	}
+
 	if endPlanet.GetShipCount() != 0 {
 		t.Error("End Planet ship count was expected to be 0 but it is:", endPlanet.GetShipCount())
 	}


### PR DESCRIPTION
@Lordmordevil found that supply mission that has changed to attack
doesn't notify the leaderboard. Later I found that if the owner of an
attacked planet changes the result of attacks sent before that won't go
to the right receiver.
