### PR TITLE
Make a new leaderboard call for serving all races

### DIFF
--- a/server/leaderboard.go
+++ b/server/leaderboard.go
@@ -53,6 +53,17 @@ func leaderboardRacesHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, string(races))
 }
 
+func leaderboardRacesInfoHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	races, err := json.Marshal(entities.Races)
+	if err != nil {
+		http.Error(w, "Internal Server Error", 500)
+		return
+	}
+	fmt.Fprintf(w, string(races))
+}
+
 func searchHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	username, ok := r.URL.Query()["player"]

--- a/server/main.go
+++ b/server/main.go
@@ -41,6 +41,7 @@ func Start() error {
 	http.HandleFunc("/console", consoleHandler)
 	http.HandleFunc("/leaderboard/players/", leaderboardPlayersHandler)
 	http.HandleFunc("/leaderboard/races/", leaderboardRacesHandler)
+	http.HandleFunc("/leaderboard/races/info/", leaderboardRacesInfoHandler)
 	http.HandleFunc("/search/", searchHandler)
 	mux.Handle("/universe", handler, conf)
 


### PR DESCRIPTION
За да няма нужда клиента да ги hardcode-ва, просто направих още един API call, който връща всички раси на `/leaderboard/races/info/`.

Примерен отговор:

``` json
[{"ID":0,"Name":"InitLab","Color":{"R":0.89215684,"G":0.031372547,"B":0.05490196}},{"ID":1,"Name":"VarnaLab","Color":{"R":0.95490193,"G":0.29411766,"B":0.05882353}},{"ID":2,"Name":"Hackafe","Color":{"R":0.9937255,"G":0.7941176,"B":0.015686275}},{"ID":3,"Name":"BurgasLab","Color":{"R":0.39215687,"G":0.8980392,"B":0.10196078}},{"ID":4,"Name":"Hackube","Color":{"R":0,"G":0.8156863,"B":1}},{"ID":5,"Name":"MegaDev","Color":{"R":1,"G":0,"B":0.78431374}}]
```
